### PR TITLE
cv_library: Fix warning about weights_only param in torch.load

### DIFF
--- a/cv_library/hierarchical_compression.py
+++ b/cv_library/hierarchical_compression.py
@@ -151,7 +151,7 @@ def load_model(
     torch.optim.Optimizer,
     list[float]
 ]:
-    checkpoint = torch.load(checkpoint_path)
+    checkpoint = torch.load(checkpoint_path, weights_only=True)
     epoch_losses = checkpoint['losses']
     model_state_dict = checkpoint['model_state_dict']
     optimizer_state_dict = checkpoint['optimizer_state_dict']


### PR DESCRIPTION
Here's the warning message for reference:

cv_library/hierarchical_compression.py:154:
  checkpoint = torch.load(checkpoint_path)

FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See
https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.